### PR TITLE
Ignore Netlify build files

### DIFF
--- a/.eleventyignore
+++ b/.eleventyignore
@@ -1,1 +1,2 @@
 README.md
+.netlify


### PR DESCRIPTION
Netlify now creates a `.netlify` folder during the build. Eleventy tries to parse the Markdown within these folder, slowing down the build and potentially breaking it if some invalid Markdown source is present.